### PR TITLE
Update S3ControlArnConverter.java

### DIFF
--- a/aws-sdk-java-v2-master/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/S3ControlArnConverter.java
+++ b/aws-sdk-java-v2-master/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/S3ControlArnConverter.java
@@ -76,7 +76,7 @@ public final class S3ControlArnConverter implements ArnConverter<S3Resource> {
                                                     .orElseThrow(() -> new IllegalArgumentException("resource type cannot be "
                                                                                                     + "null"));
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Unknown outpost ARN type '" + outpostSubresource.resourceType() + "'");
+            throw new IllegalArgumentException("Unknown outpost ARN type '" + outpostSubresource.resourceType() + "'", e);
         }
 
         String outpostId = intermediateOutpostResource.outpostId();


### PR DESCRIPTION
While wrapping the caught exception into a custom one, information about the caught exception is being lost, including information about the stack trace of the exception.