### PR TITLE
Update S3ControlArnConverter.java

### DIFF
--- a/aws-sdk-java-v2-master/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/S3ControlArnConverter.java
+++ b/aws-sdk-java-v2-master/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/S3ControlArnConverter.java
@@ -54,7 +54,7 @@ public final class S3ControlArnConverter implements ArnConverter<S3Resource> {
                 arn.resource().resourceType().map(S3ControlResourceType::fromValue)
                    .orElseThrow(() -> new IllegalArgumentException("resource type cannot be null"));
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Unknown ARN type '" + arn.resource().resourceType() + "'");
+            throw new IllegalArgumentException("Unknown ARN type '" + arn.resource().resourceType() + "'", e);
         }
 
         switch (s3ResourceType) {


### PR DESCRIPTION
While wrapping the caught exception into a custom one, information about the caught exception is being lost, including information about the stack trace of the exception.