### PR TITLE
Use the Regions enum

### DIFF
--- a/aws-toolkit-eclipse-master/bundles/com.amazonaws.eclipse.sdk.ui/samples/AmazonEC2SpotInstances-GettingStarted/Requests.java
+++ b/aws-toolkit-eclipse-master/bundles/com.amazonaws.eclipse.sdk.ui/samples/AmazonEC2SpotInstances-GettingStarted/Requests.java
@@ -77,7 +77,7 @@ public class Requests {
 
         ec2 = AmazonEC2ClientBuilder.standard()
             .withCredentials(new AWSStaticCredentialsProvider(credentials))
-            .withRegion("us-west-2")
+            .withRegion(Regions.US_WEST_2)
             .build();
     }
 


### PR DESCRIPTION
AWS Region is set using a String. Recommendation is to use the Regions enum