### PR TITLE
Use %d instead of %s to format an int

### DIFF
--- a/aws-cloudtrail-processing-library-master/src/main/java/com/amazonaws/services/cloudtrail/processinglibrary/progress/BasicPollQueueInfo.java
+++ b/aws-cloudtrail-processing-library-master/src/main/java/com/amazonaws/services/cloudtrail/processinglibrary/progress/BasicPollQueueInfo.java
@@ -47,7 +47,7 @@ public class BasicPollQueueInfo implements ProgressInfo{
 
     @Override
     public String toString() {
-        return String.format("{isSuccess: %s, polledMessageCount: %s}", isSuccess, polledMessageCount);
+        return String.format("{isSuccess: %s, polledMessageCount: %d}", isSuccess, polledMessageCount);
     }
 
 }


### PR DESCRIPTION
This it to avoid a locale issue, as pointed out by Guru Reviewer.